### PR TITLE
Made all the options menu Tecla accessible. Solves issue #1.

### DIFF
--- a/src/org/geometerplus/android/fbreader/BookmarksActivity.java
+++ b/src/org/geometerplus/android/fbreader/BookmarksActivity.java
@@ -68,7 +68,7 @@ public class BookmarksActivity extends TabActivity implements MenuItem.OnMenuIte
     ListView list;
     Activity myActivity;
     
-    private InputAccess inputAccess = new InputAccess(this, false);
+    private InputAccess inputAccess = new InputAccess(this, true);
 
 	private ListView createTab(String tag, int id, final String label) {
 		final TabHost host = getTabHost();

--- a/src/org/geometerplus/android/fbreader/FBReader.java
+++ b/src/org/geometerplus/android/fbreader/FBReader.java
@@ -83,7 +83,7 @@ public final class FBReader extends ZLAndroidActivity {
     final static int AUTO_SPEAK_CODE = 3;
 
 	private int myFullScreenFlag;
-	private InputAccess inputAccess = new InputAccess(this, false);
+	private InputAccess inputAccess = new InputAccess(this, true);
 
 	private static final String PLUGIN_ACTION_PREFIX = "___";
 	private final List<PluginApi.ActionInfo> myPluginActions =

--- a/src/org/geometerplus/android/fbreader/network/bookshare/Bookshare_OM_List.java
+++ b/src/org/geometerplus/android/fbreader/network/bookshare/Bookshare_OM_List.java
@@ -67,7 +67,7 @@ public class Bookshare_OM_List extends ListActivity{
 	private int START_BOOKSHARE_OM_DOWNLOAD_PASSWORD = 1;
 	private int BOOKSHARE_OM_SELECTED = 2;
 	private int downloadsRemaining = 0;
-	private InputAccess inputAccess = new InputAccess(this, false);
+	private InputAccess inputAccess = new InputAccess(this, true);
 
 	protected void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);

--- a/src/org/geometerplus/android/fbreader/network/bookshare/Bookshare_Webservice_Login.java
+++ b/src/org/geometerplus/android/fbreader/network/bookshare/Bookshare_Webservice_Login.java
@@ -74,7 +74,7 @@ public class Bookshare_Webservice_Login extends Activity{
 	private String developerKey = BookshareDeveloperKey.DEVELOPER_KEY;
 	private boolean isOM = false;
 	private String response;
-	private InputAccess inputAccess = new InputAccess(this, false);
+	private InputAccess inputAccess = new InputAccess(this, true);
 
 	protected void onCreate(Bundle savedInstanceState){
 		super.onCreate(savedInstanceState);


### PR DESCRIPTION
Currently pressing the menu button open up the custom accessible menu even in the absence of Tecla. This is done so that the tester can test if the accessible options menus are working as expected without having the need to install Tecla Access(https://play.google.com/store/apps/details?id=ca.idi.tekla&hl=en). A later pull request will solve this issue with minor changes. i.e accessible options menu will appear only when Tecla keyboard is the selected IME.
