### PR TITLE
Fixed bug #24

### DIFF
--- a/src/org/geometerplus/android/fbreader/benetech/ScreenUnlockReceiver.java
+++ b/src/org/geometerplus/android/fbreader/benetech/ScreenUnlockReceiver.java
@@ -1,0 +1,24 @@
+package org.geometerplus.android.fbreader.benetech;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+public class ScreenUnlockReceiver extends BroadcastReceiver{
+
+	
+		public static boolean wasScreenunlocked = true;
+
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
+				wasScreenunlocked = false;
+				Toast.makeText(context, "receiver scrren off", Toast.LENGTH_LONG).show();
+			} else if (intent.getAction().equals(Intent.ACTION_USER_PRESENT)) {
+				wasScreenunlocked = true;
+				Toast.makeText(context, "receiver screen on", Toast.LENGTH_LONG).show();
+			}
+		}
+
+}

--- a/src/org/geometerplus/android/fbreader/benetech/SpeakActivity.java
+++ b/src/org/geometerplus/android/fbreader/benetech/SpeakActivity.java
@@ -322,6 +322,12 @@ public class SpeakActivity extends Activity implements TextToSpeech.OnInitListen
         }
 
         myPreferences = getSharedPreferences("GoReadTTS", MODE_PRIVATE);
+		
+		IntentFilter filter = new IntentFilter(Intent.ACTION_SCREEN_ON);
+		filter.addAction(Intent.ACTION_SCREEN_OFF);
+		filter.addAction(Intent.ACTION_USER_PRESENT);
+		BroadcastReceiver mReceiver = new ScreenUnlockReceiver();
+		registerReceiver(mReceiver, filter);
 	}
 
 	@Override


### PR DESCRIPTION
created a receiver that receives the unlocking event and makes sure that
the reading automatically doesn't start after we unlock.
