### PR TITLE
Fbr 538 gesture to select a word and start playback at it

### DIFF
--- a/FBReader/src/main/java/org/accessibility/SimpleGestureFilter.java
+++ b/FBReader/src/main/java/org/accessibility/SimpleGestureFilter.java
@@ -138,8 +138,11 @@ public class SimpleGestureFilter extends GestureDetector.SimpleOnGestureListener
 
     @Override
     public boolean onDoubleTap(MotionEvent arg0) {
-        this.listener.onDoubleTap();
-        return true;
+        if (this.mode == MODE_DYNAMIC) {        // we owe an ACTION_UP, so we fake an
+            arg0.setAction(ACTION_FAKE);      //action which will be converted to an ACTION_UP later.
+            this.context.dispatchTouchEvent(arg0);
+        }
+        return false;
     }
 
     @Override

--- a/FBReader/src/main/java/org/accessibility/SimpleGestureFilter.java
+++ b/FBReader/src/main/java/org/accessibility/SimpleGestureFilter.java
@@ -147,7 +147,7 @@ public class SimpleGestureFilter extends GestureDetector.SimpleOnGestureListener
 
     @Override
     public boolean onDoubleTapEvent(MotionEvent arg0) {
-        return true;
+        return false;
     }
 
     @Override
@@ -165,7 +165,7 @@ public class SimpleGestureFilter extends GestureDetector.SimpleOnGestureListener
     public interface SimpleGestureListener {
         void onSwipe(int direction);
 
-        void onDoubleTap();
+        void onTwoFingerDoubleTap();
     }
 
 }

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/FBReader.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/FBReader.java
@@ -131,7 +131,7 @@ public class FBReader extends ZLAndroidActivityforActionBar {
         //todo:
 		//inputAccess.onCreate();
 		final ZLAndroidLibrary zlibrary = (ZLAndroidLibrary)ZLibrary.Instance();
-        
+
         accessibilityManager = (AccessibilityManager) getApplicationContext().getSystemService(Context.ACCESSIBILITY_SERVICE);
 		myFullScreenFlag = zlibrary.ShowStatusBarOption.getValue() ? 0 : WindowManager.LayoutParams.FLAG_FULLSCREEN;
 
@@ -158,7 +158,7 @@ public class FBReader extends ZLAndroidActivityforActionBar {
 		fbReader.addAction(ActionCode.SHOW_TOC, new ShowTOCAction(this, fbReader));
 		fbReader.addAction(ActionCode.SHOW_BOOKMARKS, new ShowBookmarksAction(this, fbReader));
 		fbReader.addAction(ActionCode.SHOW_NETWORK_LIBRARY, new ShowNetworkLibraryAction(this, fbReader));
-		
+
 		fbReader.addAction(ActionCode.SHOW_MENU, new ShowMenuAction(this, fbReader));
 		fbReader.addAction(ActionCode.SHOW_NAVIGATION, new ShowNavigationAction(this, fbReader));
 		fbReader.addAction(ActionCode.SEARCH, new SearchAction(this, fbReader));
@@ -424,13 +424,13 @@ public class FBReader extends ZLAndroidActivityforActionBar {
 	public void navigate() {
         ((NavigationPopup)FBReaderApp.Instance().getPopupById(NavigationPopup.ID)).runNavigation();
 	}
-    
-    /** 
+
+    /**
      * If book is available, add it to application title.
      */
     private void setApplicationTitle() {
         final Book currentBook = Library.getRecentBook();
-        
+
         if (currentBook != null) {
             setTitle(currentBook.getTitle());
         }
@@ -516,4 +516,7 @@ public class FBReader extends ZLAndroidActivityforActionBar {
         }
     }
 
+	public void selectSentenceFromView() {
+		return;
+	}
 }

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/FBReader.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/FBReader.java
@@ -519,4 +519,9 @@ public class FBReader extends ZLAndroidActivityforActionBar {
 	public void selectSentenceFromView() {
 		return;
 	}
+
+	public void playOrPause() {
+		return;
+	}
+
 }

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/FBReader.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/FBReader.java
@@ -186,7 +186,11 @@ public class FBReader extends ZLAndroidActivityforActionBar {
 		fbReader.addAction(ActionCode.ABOUT_GOREAD, new ShowAboutGoReadAction(this, fbReader));
 		fbReader.addAction(ActionCode.LOGOUT_BOOKSHARE, new LogoutFromBookshareAction(this, fbReader));
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+		fbReader.addAction(ActionCode.SELECT_SENTENCE, new SelectSentenceAction(this, fbReader));
+		fbReader.addAction(ActionCode.PLAY_OR_PAUSE, new PlayOrPauseAction(this, fbReader));
+		fbReader.addAction(ActionCode.TOGGLE_BARS, new ToggleBarsAction(this, fbReader));
+
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         int currentVersion = zlibrary.getVersionCode();
         int userManualVersion = prefs.getInt(PREFS_USER_MANUAL_VERSION, 0);
 
@@ -521,6 +525,10 @@ public class FBReader extends ZLAndroidActivityforActionBar {
 	}
 
 	public void playOrPause() {
+		return;
+	}
+
+	public void toggleDisplayBars(){
 		return;
 	}
 

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/PlayOrPauseAction.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/PlayOrPauseAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2007-2012 Geometer Plus <contact@geometerplus.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+package org.geometerplus.android.fbreader;
+
+import org.geometerplus.fbreader.fbreader.FBReaderApp;
+
+public class PlayOrPauseAction extends FBAndroidAction {
+
+	private FBReader myReader = null;
+
+	public PlayOrPauseAction(FBReader baseActivity, FBReaderApp fbreader) {
+		super(baseActivity, fbreader);
+		myReader = baseActivity;
+	}
+
+	@Override
+	protected void run(Object ... params) {
+		myReader.playOrPause();
+	}
+}

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/SelectSentenceAction.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/SelectSentenceAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2007-2012 Geometer Plus <contact@geometerplus.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+package org.geometerplus.android.fbreader;
+
+import org.geometerplus.fbreader.fbreader.FBReaderApp;
+
+public class SelectSentenceAction extends FBAndroidAction {
+
+	private FBReader myReader = null;
+
+	public SelectSentenceAction(FBReader baseActivity, FBReaderApp fbreader) {
+		super(baseActivity, fbreader);
+		myReader = baseActivity;
+	}
+
+	@Override
+	protected void run(Object ... params) {
+		myReader.selectSentenceFromView();
+	}
+}

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/ToggleBarsAction.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/ToggleBarsAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2007-2012 Geometer Plus <contact@geometerplus.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+package org.geometerplus.android.fbreader;
+
+import org.geometerplus.fbreader.fbreader.FBReaderApp;
+
+public class ToggleBarsAction extends FBAndroidAction {
+
+	private FBReader myReader = null;
+
+	public ToggleBarsAction(FBReader baseActivity, FBReaderApp fbreader) {
+		super(baseActivity, fbreader);
+		myReader = baseActivity;
+	}
+
+	@Override
+	protected void run(Object ... params) {
+		myReader.toggleDisplayBars();
+	}
+}

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/benetech/FBReaderWithNavigationBar.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/benetech/FBReaderWithNavigationBar.java
@@ -118,8 +118,6 @@ public class FBReaderWithNavigationBar extends FBReaderWithPinchZoom implements 
 
         super.onCreate(savedInstanceState);
         fbReader = (FBReaderApp)FBReaderApp.Instance();
-        fbReader.addAction(ActionCode.SELECT_SENTENCE, new SelectSentenceAction(this, fbReader));
-        fbReader.addAction(ActionCode.PLAY_OR_PAUSE, new PlayOrPauseAction(this, fbReader));
         if(savedInstanceState != null){
             activityResuming = savedInstanceState.getBoolean(ACTIVITY_RESUMING_STATE, false);
         }
@@ -658,6 +656,21 @@ public class FBReaderWithNavigationBar extends FBReaderWithPinchZoom implements 
             pause();
         } else {
             play();
+        }
+    }
+
+    @Override
+    public void toggleDisplayBars(){
+        if(getSupportActionBar() != null){
+            View playBar = findViewById(R.id.navigation_bar_id);
+            if(getSupportActionBar().isShowing()){
+                getSupportActionBar().hide();
+                if(playBar != null)playBar.setVisibility(View.GONE);
+            }
+            else {
+                getSupportActionBar().show();
+                if(playBar != null)playBar.setVisibility(View.VISIBLE);
+            }
         }
     }
 

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/benetech/FBReaderWithNavigationBar.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/benetech/FBReaderWithNavigationBar.java
@@ -519,10 +519,10 @@ public class FBReaderWithNavigationBar extends FBReaderWithPinchZoom implements 
         ZLTextRegion region = fbReader.getTextView().getDoubleTapSelectedRegion();
 
         boolean shouldHighlightSentence = false;
-        if(region == null && fbReader.getTextView().didScroll){
+        if(region == null && fbReader.getTextView().didScroll()){
             region = fbReader.getTextView().getTopOfPageRegion();
             shouldHighlightSentence = true;
-            fbReader.getTextView().didScroll = false;
+            fbReader.getTextView().resetDidScroll();
         }
         int wordOffset = 0;
         if(region != null){

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/benetech/FBReaderWithNavigationBar.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/benetech/FBReaderWithNavigationBar.java
@@ -517,13 +517,18 @@ public class FBReaderWithNavigationBar extends FBReaderWithPinchZoom implements 
         String text = "";
         final FBReaderApp fbReader = (FBReaderApp)FBReaderApp.Instance();
         ZLTextRegion region = fbReader.getTextView().getDoubleTapSelectedRegion();
-        int offset = 0;
+
+        boolean shouldHighlightSentence = false;
+        if(region == null && fbReader.getTextView().didScroll){
+            region = fbReader.getTextView().getTopOfPageRegion();
+            shouldHighlightSentence = true;
+            fbReader.getTextView().didScroll = false;
+        }
         int wordOffset = 0;
         if(region != null){
             myParagraphIndex = region.getSoul().getParagraphIndex();
             fbReader.getTextView().resetLatestLongPressSelectedRegion();
             if(region.getSoul() instanceof ZLTextWordRegionSoul){
-                offset = ((ZLTextWordRegionSoul) region.getSoul()).Word.getParagraphOffset();
                 wordOffset = (region.getSoul().getStartElementIndex() /2) +1;
             }
         }
@@ -538,15 +543,6 @@ public class FBReaderWithNavigationBar extends FBReaderWithPinchZoom implements 
                 break;
             }
         }
-//        if (!"".equals(text) && !myApi.isPageEndOfText()) {
-//            myApi.setPageStart(new TextPosition(myParagraphIndex, 0, 0));
-//        }
-
-//        if(wordOffset > 0 && wordOffset < wordsList.size()){
-//            for(int c = wordOffset; c > 0; c --){
-//                wordsList.remove(0);
-//            }
-//        }
 
         if (null != wordsList) {
             mySentences = TtsSentenceExtractor.build(wordsList, paragraphIndexesList, myTTS.getLanguage());
@@ -566,16 +562,17 @@ public class FBReaderWithNavigationBar extends FBReaderWithPinchZoom implements 
                 myCurrentSentence = currentSentence;
             }
 
-            highlightParagraph();
+            if(shouldHighlightSentence){
+                highlightSentence(myCurrentSentence);
+            }
+            else {
+                highlightParagraph();
+            }
         }
 
         //Disable next section button if this is the last paragraph
         if (myParagraphIndex >= (myParagraphsNumber - 1)) {
             disableNextButton();
-        }
-
-        if(offset > 0){
-            text = text.substring(offset);
         }
         return text;
     }

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/benetech/SpeakActivity.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/benetech/SpeakActivity.java
@@ -808,7 +808,7 @@ public class SpeakActivity {}/*extends Activity implements TextToSpeech.OnInitLi
 //    }
 //
 //    @Override
-//    public void onDoubleTap() {
+//    public void onTwoFingerDoubleTap() {
 //        myVib.vibrate(VIBE_PATTERN, -1);
 //        ((ZLAndroidApplication) getApplication()).trackGoogleAnalyticsEvent(Analytics.EVENT_CATEGORY_UI, Analytics.EVENT_ACTION_GESTURE, Analytics.EVENT_LABEL_PLAY_PAUSE);
 //        playOrPause();

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/ActionCode.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/ActionCode.java
@@ -83,4 +83,6 @@ public interface ActionCode {
     String ACCESSIBLE_NAVIGATION = "accessible_navigation";
 	String LOGOUT_BOOKSHARE = "logout_from_bookshare";
 	String ABOUT_GOREAD = "about_goread";
+
+	String SELECT_SENTENCE = "select_sentence";
 }

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/ActionCode.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/ActionCode.java
@@ -85,4 +85,6 @@ public interface ActionCode {
 	String ABOUT_GOREAD = "about_goread";
 
 	String SELECT_SENTENCE = "select_sentence";
+	String PLAY_OR_PAUSE = "play_or_pause";
+
 }

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/ActionCode.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/ActionCode.java
@@ -86,5 +86,6 @@ public interface ActionCode {
 
 	String SELECT_SENTENCE = "select_sentence";
 	String PLAY_OR_PAUSE = "play_or_pause";
+	String TOGGLE_BARS = "toggle_bars";
 
 }

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBReaderApp.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBReaderApp.java
@@ -57,7 +57,7 @@ public final class FBReaderApp extends ZLApplication {
 		new ZLBooleanOption("KeysOptions", "UseSeparateBindings", false);
 
 	public final ZLBooleanOption EnableDoubleTapOption =
-		new ZLBooleanOption("Options", "EnableDoubleTap", false);
+		new ZLBooleanOption("Options", "EnableDoubleTap", true);
 	public final ZLBooleanOption NavigateAllWordsOption =
 		new ZLBooleanOption("Options", "NavigateAllWords", false);
 
@@ -187,7 +187,7 @@ public final class FBReaderApp extends ZLApplication {
 			}
 		});
 	}
-    
+
     public void openBook(final Book book, final Bookmark bookmark, final Activity activity) {
     		if (book == null) {
     			return;
@@ -197,7 +197,7 @@ public final class FBReaderApp extends ZLApplication {
     				return;
     			}
     		}
-        
+
             if (activity != null) {
         			UIUtil.wait("loadingBook", new Runnable() {
                         @Override
@@ -378,7 +378,7 @@ public final class FBReaderApp extends ZLApplication {
 
 	private static class BookmarkDescription extends CancelActionDescription {
 		final Bookmark Bookmark;
-		
+
 		BookmarkDescription(Bookmark b) {
 			super(CancelActionType.returnTo, b.getText());
 			Bookmark = b;
@@ -490,7 +490,7 @@ public final class FBReaderApp extends ZLApplication {
 			return null;
 		}
 
-		int index = cursor.getParagraphIndex();	
+		int index = cursor.getParagraphIndex();
 		if (cursor.isEndOfParagraph()) {
 			++index;
 		}
@@ -507,15 +507,15 @@ public final class FBReaderApp extends ZLApplication {
 		}
 		return treeToSelect;
 	}
-    
+
     public LinkedHashMap<String, Integer> getDaisyPageMap() {
         if (null != Model) {
-            return Model.getDaisyPageMap();    
+            return Model.getDaisyPageMap();
         } else {
             return new LinkedHashMap<String, Integer>();
         }
     }
-    
+
     public String getLastDaisyPage() {
         if (null != Model) {
             return Model.getLastDaisyPage();

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
@@ -56,6 +56,16 @@ public final class FBView extends ZLTextView {
 	private String myZoneMapId;
 	private TapZoneMap myZoneMap;
 
+	private ZLTextRegion latestLongPressSelectedRegion = null;
+
+	public ZLTextRegion getLatestLongPressSelectedRegion(){
+		return latestLongPressSelectedRegion;
+	}
+
+	public void resetLatestLongPressSelectedRegion(){
+		latestLongPressSelectedRegion = null;
+	}
+
 	private TapZoneMap getZoneMap() {
 		//final String id =
 		//	ScrollingPreferences.Instance().TapZonesSchemeOption.getValue().toString();
@@ -213,7 +223,7 @@ public final class FBView extends ZLTextView {
 		final ZLTextRegion region = findRegion(x, y, MAX_SELECTION_DISTANCE, ZLTextRegion.AnyRegionFilter);
 		if (region != null) {
 			final ZLTextRegion.Soul soul = region.getSoul();
-			boolean doSelectRegion = false;
+			boolean doSelectRegion = true;
 			if (soul instanceof ZLTextWordRegionSoul) {
 				switch (myReader.WordTappingActionOption.getValue()) {
 					case startSelecting:
@@ -223,6 +233,7 @@ public final class FBView extends ZLTextView {
 						if (cursor != ZLTextSelectionCursor.None) {
 							moveSelectionCursorTo(cursor, x, y);
 						}
+						latestLongPressSelectedRegion = region;
 						return true;
 					case selectSingleWord:
 					case openDictionary:

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
@@ -96,11 +96,14 @@ public final class FBView extends ZLTextView {
 			myReader.doAction(ActionCode.PROCESS_HYPERLINK);
 			return true;
 		}
-
-		myReader.doAction(getZoneMap().getActionByCoordinates(
-			x, y, myContext.getWidth(), myContext.getHeight(),
-			isDoubleTapSupported() ? TapZoneMap.Tap.singleNotDoubleTap : TapZoneMap.Tap.singleTap
-		), x, y);
+		String action = getZoneMap().getActionByCoordinates(
+				x, y, myContext.getWidth(), myContext.getHeight(),
+				isDoubleTapSupported() ? TapZoneMap.Tap.singleNotDoubleTap : TapZoneMap.Tap.singleTap
+		);
+		if(action == null){ //we're not catching any other events for this tap
+			action = ActionCode.TOGGLE_BARS;
+		}
+		myReader.doAction(action, x, y);
 
 		return true;
 	}

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
@@ -66,6 +66,11 @@ public final class FBView extends ZLTextView {
 		return doubleTapSelectedRegion;
 	}
 
+	public ZLTextRegion getTopOfPageRegion(){
+		return findRegion(25, 25, MAX_SELECTION_DISTANCE, ZLTextRegion.AnyRegionFilter);
+	}
+
+
 	public void resetLatestLongPressSelectedRegion(){
 		doubleTapSelectedRegion = null;
 	}
@@ -352,6 +357,14 @@ public final class FBView extends ZLTextView {
 
 		new MoveCursorAction(myReader, direction).run();
 		return true;
+	}
+
+	public boolean didScroll = false;
+
+	@Override
+	public synchronized void onScrollingFinished(PageIndex pageIndex) {
+		super.onScrollingFinished(pageIndex);
+		didScroll = true;
 	}
 
 	@Override

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
@@ -19,20 +19,24 @@
 
 package org.geometerplus.fbreader.fbreader;
 
-import java.util.*;
-
-import org.geometerplus.zlibrary.core.util.ZLColor;
-import org.geometerplus.zlibrary.core.library.ZLibrary;
-import org.geometerplus.zlibrary.core.view.ZLPaintContext;
-import org.geometerplus.zlibrary.core.filesystem.ZLFile;
-import org.geometerplus.zlibrary.core.filesystem.ZLResourceFile;
-
-import org.geometerplus.zlibrary.text.model.ZLTextModel;
-import org.geometerplus.zlibrary.text.view.*;
-
 import org.geometerplus.fbreader.bookmodel.BookModel;
 import org.geometerplus.fbreader.bookmodel.FBHyperlinkType;
 import org.geometerplus.fbreader.bookmodel.TOCTree;
+import org.geometerplus.zlibrary.core.filesystem.ZLFile;
+import org.geometerplus.zlibrary.core.filesystem.ZLResourceFile;
+import org.geometerplus.zlibrary.core.library.ZLibrary;
+import org.geometerplus.zlibrary.core.util.ZLColor;
+import org.geometerplus.zlibrary.core.view.ZLPaintContext;
+import org.geometerplus.zlibrary.text.model.ZLTextModel;
+import org.geometerplus.zlibrary.text.view.ZLTextHyperlink;
+import org.geometerplus.zlibrary.text.view.ZLTextHyperlinkRegionSoul;
+import org.geometerplus.zlibrary.text.view.ZLTextImageRegionSoul;
+import org.geometerplus.zlibrary.text.view.ZLTextRegion;
+import org.geometerplus.zlibrary.text.view.ZLTextSelectionCursor;
+import org.geometerplus.zlibrary.text.view.ZLTextView;
+import org.geometerplus.zlibrary.text.view.ZLTextWordRegionSoul;
+
+import java.util.ArrayList;
 
 public final class FBView extends ZLTextView {
 	private FBReaderApp myReader;
@@ -56,14 +60,14 @@ public final class FBView extends ZLTextView {
 	private String myZoneMapId;
 	private TapZoneMap myZoneMap;
 
-	private ZLTextRegion latestLongPressSelectedRegion = null;
+	private ZLTextRegion doubleTapSelectedRegion = null;
 
-	public ZLTextRegion getLatestLongPressSelectedRegion(){
-		return latestLongPressSelectedRegion;
+	public ZLTextRegion getDoubleTapSelectedRegion(){
+		return doubleTapSelectedRegion;
 	}
 
 	public void resetLatestLongPressSelectedRegion(){
-		latestLongPressSelectedRegion = null;
+		doubleTapSelectedRegion = null;
 	}
 
 	private TapZoneMap getZoneMap() {
@@ -111,9 +115,11 @@ public final class FBView extends ZLTextView {
 		if (super.onFingerDoubleTap(x, y)) {
 			return true;
 		}
-		myReader.doAction(getZoneMap().getActionByCoordinates(
-			x, y, myContext.getWidth(), myContext.getHeight(), TapZoneMap.Tap.doubleTap
-		), x, y);
+
+		doubleTapSelectedRegion = findRegion(x, y, MAX_SELECTION_DISTANCE, ZLTextRegion.AnyRegionFilter);
+
+
+		myReader.doAction(ActionCode.SELECT_SENTENCE);
 		return true;
 	}
 
@@ -233,7 +239,7 @@ public final class FBView extends ZLTextView {
 						if (cursor != ZLTextSelectionCursor.None) {
 							moveSelectionCursorTo(cursor, x, y);
 						}
-						latestLongPressSelectedRegion = region;
+						doubleTapSelectedRegion = region;
 						return true;
 					case selectSingleWord:
 					case openDictionary:
@@ -247,7 +253,7 @@ public final class FBView extends ZLTextView {
 			} else if (soul instanceof ZLTextHyperlinkRegionSoul) {
 				doSelectRegion = true;
 			}
-        
+
 			if (doSelectRegion) {
 				selectRegion(region);
 				myReader.getViewWidget().reset();
@@ -367,7 +373,7 @@ public final class FBView extends ZLTextView {
 		if ("".equals(filePath)) {
 			return null;
 		}
-		
+
 		final ZLFile file = ZLFile.createFileByPath(filePath);
 		if (file == null || !file.exists()) {
 			return null;

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
@@ -111,15 +111,20 @@ public final class FBView extends ZLTextView {
 	}
 
 	@Override
-	public boolean onFingerDoubleTap(int x, int y) {
-		if (super.onFingerDoubleTap(x, y)) {
+	public boolean onFingerDoubleTap(int x, int y, boolean multitouch) {
+		if (super.onFingerDoubleTap(x, y, multitouch)) {
 			return true;
 		}
 
-		doubleTapSelectedRegion = findRegion(x, y, MAX_SELECTION_DISTANCE, ZLTextRegion.AnyRegionFilter);
+		if(!multitouch){
+			doubleTapSelectedRegion = findRegion(x, y, MAX_SELECTION_DISTANCE, ZLTextRegion.AnyRegionFilter);
+			myReader.doAction(ActionCode.SELECT_SENTENCE);
+		}
+		else {
+			doubleTapSelectedRegion = null;
+			myReader.doAction(ActionCode.PLAY_OR_PAUSE);
+		}
 
-
-		myReader.doAction(ActionCode.SELECT_SENTENCE);
 		return true;
 	}
 
@@ -239,7 +244,6 @@ public final class FBView extends ZLTextView {
 						if (cursor != ZLTextSelectionCursor.None) {
 							moveSelectionCursorTo(cursor, x, y);
 						}
-						doubleTapSelectedRegion = region;
 						return true;
 					case selectSingleWord:
 					case openDictionary:

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBView.java
@@ -62,6 +62,8 @@ public final class FBView extends ZLTextView {
 
 	private ZLTextRegion doubleTapSelectedRegion = null;
 
+	private boolean didScroll = false;
+
 	public ZLTextRegion getDoubleTapSelectedRegion(){
 		return doubleTapSelectedRegion;
 	}
@@ -70,6 +72,13 @@ public final class FBView extends ZLTextView {
 		return findRegion(25, 25, MAX_SELECTION_DISTANCE, ZLTextRegion.AnyRegionFilter);
 	}
 
+	public boolean didScroll() {
+		return didScroll;
+	}
+
+	public void resetDidScroll(){
+		didScroll = false;
+	}
 
 	public void resetLatestLongPressSelectedRegion(){
 		doubleTapSelectedRegion = null;
@@ -359,7 +368,6 @@ public final class FBView extends ZLTextView {
 		return true;
 	}
 
-	public boolean didScroll = false;
 
 	@Override
 	public synchronized void onScrollingFinished(PageIndex pageIndex) {

--- a/FBReader/src/main/java/org/geometerplus/zlibrary/core/view/ZLView.java
+++ b/FBReader/src/main/java/org/geometerplus/zlibrary/core/view/ZLView.java
@@ -111,7 +111,7 @@ abstract public class ZLView {
 		return false;
 	}
 
-	public boolean onFingerDoubleTap(int x, int y) {
+	public boolean onFingerDoubleTap(int x, int y, boolean multitouch) {
 		return false;
 	}
 

--- a/FBReader/src/main/java/org/geometerplus/zlibrary/text/view/ZLTextRegion.java
+++ b/FBReader/src/main/java/org/geometerplus/zlibrary/text/view/ZLTextRegion.java
@@ -35,10 +35,17 @@ public final class ZLTextRegion {
 			EndElementIndex = endElementIndex;
 		}
 
+		public int getParagraphIndex() {
+			return ParagraphIndex;
+		}
+		public int getStartElementIndex() {
+			return StartElementIndex;
+		}
+
 		final boolean accepts(ZLTextElementArea area) {
 			return compareTo(area) == 0;
 		}
-	
+
 		@Override
 		public final boolean equals(Object other) {
 			if (other == this) {

--- a/FBReader/src/main/java/org/geometerplus/zlibrary/ui/android/view/ZLAndroidWidget.java
+++ b/FBReader/src/main/java/org/geometerplus/zlibrary/ui/android/view/ZLAndroidWidget.java
@@ -295,7 +295,18 @@ public class ZLAndroidWidget extends View implements ZLViewWidget, View.OnLongCl
 			myPendingShortClickRunnable = null;
 		}
 	}
+
+	private class DoubleClickRunnable implements Runnable {
+		public void run() {
+			final ZLView view = ZLApplication.Instance().getCurrentView();
+			view.onFingerDoubleTap(myPressedX, myPressedY);
+			myPendingPress = false;
+			myPendingDoubleClickRunnable = null;
+		}
+	}
+
 	private volatile ShortClickRunnable myPendingShortClickRunnable;
+	private volatile DoubleClickRunnable myPendingDoubleClickRunnable;
 
 	private volatile boolean myPendingPress;
 	private volatile boolean myPendingDoubleTap;
@@ -320,10 +331,10 @@ public class ZLAndroidWidget extends View implements ZLViewWidget, View.OnLongCl
 					}
 					if (myPendingPress) {
 						if (view.isDoubleTapSupported()) {
-        					if (myPendingShortClickRunnable == null) {
-            					myPendingShortClickRunnable = new ShortClickRunnable();
+        					if (myPendingDoubleClickRunnable == null) {
+								myPendingDoubleClickRunnable = new DoubleClickRunnable();
         					}
-        					postDelayed(myPendingShortClickRunnable, ViewConfiguration.getDoubleTapTimeout());
+        					postDelayed(myPendingDoubleClickRunnable, ViewConfiguration.getDoubleTapTimeout());
 						} else {
 							view.onFingerSingleTap(x, y);
 						}


### PR DESCRIPTION
Relocated some methods in the code in order to better be able to follow code flow.
Enabled double tap in constants.
Removed double tap event on gesture listener so that it always falls through to ZLViewWidget where we can get the accurate coords on the text.
Catching double tap on ZLViewWidget as mentioned above. Also catching two-finger double tap on ZLViewWidget.
Added two new actions to communicate from ZLViewWidget to FBReader