### PR TITLE
Add option to navigate by sentence.

### DIFF
--- a/FBReader/src/main/assets/resources/application/en.xml
+++ b/FBReader/src/main/assets/resources/application/en.xml
@@ -483,6 +483,10 @@
 			</node>
 			<node name="moresettings" value="More settings">
 				<node name="summary" value="Dictionary, Images"/>
+				<node name="navigateBySentence" value="Navigation">
+					<node name="summaryOn" value="Navigate by sentence"/>
+					<node name="summaryOff" value="Navigate by paragraph"/>
+				</node>
 			</node>
 			<node name="dictionary" value="Dictionary">
 				<node name="summary" value="Dictionary settings"/>

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/preferences/PreferenceActivity.java
@@ -275,6 +275,7 @@ public class PreferenceActivity extends ZLPreferenceActivity {
         final Screen moreSettingsScreen = createPreferenceScreen("moresettings");
         myScreen.removePreference(dictionaryScreen.myScreen);
         myScreen.removePreference(imagesScreen.myScreen);
+        moreSettingsScreen.addOption(fbReader.NavigateBySentenceOption, "navigateBySentence");
         moreSettingsScreen.addPreference(dictionaryScreen.myScreen);
         moreSettingsScreen.addPreference(imagesScreen.myScreen);
     }

--- a/FBReader/src/main/java/org/geometerplus/android/fbreader/preferences/ZLPreferenceActivity.java
+++ b/FBReader/src/main/java/org/geometerplus/android/fbreader/preferences/ZLPreferenceActivity.java
@@ -27,7 +27,7 @@ import android.preference.PreferenceScreen;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.LinearLayout;
+import android.view.ViewGroup;
 
 import org.benetech.android.R;
 import org.geometerplus.zlibrary.core.options.ZLBooleanOption;
@@ -166,7 +166,7 @@ abstract class ZLPreferenceActivity extends SettingsPreferencesActivity {
 		if(dialog != null) {
 			Toolbar bar;
 
-			LinearLayout root = (LinearLayout) dialog.findViewById(android.R.id.list).getParent();
+			ViewGroup root = (ViewGroup) dialog.findViewById(android.R.id.list).getParent();
 			bar = (Toolbar) LayoutInflater.from(this).inflate(R.layout.sub_settings, root, false);
 			root.addView(bar, 0); // insert at top
 

--- a/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBReaderApp.java
+++ b/FBReader/src/main/java/org/geometerplus/fbreader/fbreader/FBReaderApp.java
@@ -113,6 +113,9 @@ public final class FBReaderApp extends ZLApplication {
 	public final ZLBooleanOption ShowPositionsInCancelMenuOption =
 		new ZLBooleanOption("CancelMenu", "positions", true);
 
+	public final ZLBooleanOption NavigateBySentenceOption =
+			new ZLBooleanOption("Options", "NavigateBySentence", false);
+
 	private final ZLKeyBindings myBindings = new ZLKeyBindings("Keys");
 
 	public final FBView BookTextView;


### PR DESCRIPTION
Adding a setting to toggle between navigating by
sentence and navigating by paragraph. The default
is paragraph, which matches the previous intended
behavior.

Opening any setting crashed the app because of a
ClassCastException from FrameLayout to LinearLayout.
I changed the cast to ViewGroup, as the code didn't
actually depend on anything more specific.

Navigation by paragraph was unreliable when
the app was reading because the TTS callback would
happen on other threads while navigation happened.
I've reposted the TTS callbacks to the main thread
to prevent threads interfering with each other.
Issue #33 is an example of this problem.

Callbacks from TTS also didn't distinguish between
utterances that had been read and utterances whose
reading had been canceled. I've added logic to track
which utterances are currently active, and ignore
callback for those that have been cancelled.

I now find that both types of navigation now work
reliably.